### PR TITLE
feat: add option to choose database docker image

### DIFF
--- a/src/getTestDatabase.ts
+++ b/src/getTestDatabase.ts
@@ -4,19 +4,30 @@ import {
 } from "@originate/docker-await-postgres";
 import { createConnection } from "typeorm";
 
+export interface Options {
+  /**
+   * Docker image to run; e.g. `postgres:12`
+   */
+  image?: string;
+}
+
 /**
  * Spins up a postgres database in a temporary Docker container. Sets the
  * environment variable, `DATABASE_URL`. Returns an object with a connection URI
  * for that database, and a function to call to stop and remove the container.
+ *
+ * @param options.image Docker image to run; e.g. `"postgres:12"` (default: "postgres:latest")
  */
-export async function getTestDatabase(): Promise<{
+export async function getTestDatabase({
+  image = "postgres:latest",
+}: Options): Promise<{
   stop: () => Promise<void>;
 }> {
   const config: Config = {
     user: "postgres",
     password: "password",
     database: "postgres",
-    image: "postgres:latest",
+    image,
     ensureShutdown: true,
   };
   const { port, stop } = await startPostgresContainer(config);

--- a/src/originate-scripts.ts
+++ b/src/originate-scripts.ts
@@ -12,8 +12,16 @@ export const program = new Command();
 program.storeOptionsAsProperties(false).version(getVersion());
 program
   .command("db:start")
+  .option(
+    "-i, --image <docker image>",
+    'docker image to run; e.g. "postgres:12"',
+    "postgres:latest"
+  )
   .description("start the dev database, or spin up a new one")
-  .action(() => dbStart());
+  .action((command: Command) => {
+    const opts = command.opts();
+    dbStart(opts.image);
+  });
 program
   .command("db:stop")
   .description(


### PR DESCRIPTION
- Adds `-i, --image <docker image>` option to `originate-scripts db:start` command
- Adds options object with optional `image` property to `getTestDatabase` function

Originate-scripts is designed to work with `postgres` images so the
image that is specified should be `postgres:<some tag>`. For example
`postgres:12` or `postgres:latest` (the default).