### PR TITLE
ci: switch test job to newer Node versions: 17, 16, & 14.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["12", "14", "15"]
+        node: ["14", "16", "17"]
     name: Test with Node v${{ matrix.node }}
     steps:
       - name: Checkout


### PR DESCRIPTION
That covers the current stable, the active LTS, and the latest
maintenance LTS releases.